### PR TITLE
Add API auth tests and CI workflow

### DIFF
--- a/.github/workflows/api-tests.yml
+++ b/.github/workflows/api-tests.yml
@@ -1,0 +1,21 @@
+name: API Tests
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: apps/api
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+      - run: npm install
+      - run: npm test

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -4,7 +4,8 @@
   "main": "index.js",
   "type": "module",
   "scripts": {
-    "start": "node index.js"
+    "start": "node index.js",
+    "test": "NODE_ENV=test node --test"
   },
   "dependencies": {
     "bcryptjs": "^2.4.3",
@@ -13,5 +14,8 @@
     "jsonwebtoken": "^9.0.2",
     "knex": "^3.1.0",
     "pg": "^8.11.3"
+  },
+  "devDependencies": {
+    "pg-mem": "^3.0.5"
   }
 }

--- a/apps/api/test/auth.test.js
+++ b/apps/api/test/auth.test.js
@@ -1,0 +1,83 @@
+import { test, before, after } from 'node:test';
+import assert from 'node:assert';
+
+let server;
+let baseUrl;
+
+before(async () => {
+  const mod = await import('../index.js');
+  await mod.ensureSchema();
+  server = mod.app.listen(0);
+  await new Promise((resolve) => server.once('listening', resolve));
+  const { port } = server.address();
+  baseUrl = `http://localhost:${port}`;
+});
+
+after(async () => {
+  await new Promise((resolve) => server.close(resolve));
+});
+
+test('authentication flow', async (t) => {
+  let token;
+
+  await t.test('register valid data', async () => {
+    const res = await fetch(`${baseUrl}/auth/register`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        name: 'Alice',
+        email: 'alice@example.com',
+        password: 'secret'
+      })
+    });
+    assert.strictEqual(res.status, 201);
+    const body = await res.json();
+    assert.ok(body.token);
+  });
+
+  await t.test('reject duplicate email', async () => {
+    const res = await fetch(`${baseUrl}/auth/register`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        name: 'Alice',
+        email: 'alice@example.com',
+        password: 'secret'
+      })
+    });
+    assert.strictEqual(res.status, 409);
+  });
+
+  await t.test('login with correct credentials', async () => {
+    const res = await fetch(`${baseUrl}/auth/login`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email: 'alice@example.com', password: 'secret' })
+    });
+    assert.strictEqual(res.status, 200);
+    const body = await res.json();
+    assert.ok(body.token);
+    token = body.token;
+  });
+
+  await t.test('login with incorrect credentials', async () => {
+    const res = await fetch(`${baseUrl}/auth/login`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email: 'alice@example.com', password: 'wrong' })
+    });
+    assert.strictEqual(res.status, 401);
+  });
+
+  await t.test('protected route requires token', async () => {
+    let res = await fetch(`${baseUrl}/me`);
+    assert.strictEqual(res.status, 401);
+
+    res = await fetch(`${baseUrl}/me`, {
+      headers: { Authorization: `Bearer ${token}` }
+    });
+    assert.strictEqual(res.status, 200);
+    const body = await res.json();
+    assert.strictEqual(body.user.email, 'alice@example.com');
+  });
+});


### PR DESCRIPTION
## Summary
- use pg-mem for in-memory database in tests
- add auth flow tests for registration, login and JWT protection
- run API tests in CI

## Testing
- `npm test --prefix apps/api`

------
https://chatgpt.com/codex/tasks/task_e_68c1a447f140832f9e4351faaf5ad087