### PR TITLE
Ensure frontend uses configured API URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,12 @@
 # finance-app
 Aplicação para gestão de finanças.
+
+## Configuração do Frontend
+
+Crie um arquivo `.env` dentro de `apps/web` com a variável abaixo para definir a URL da API consumida pelo frontend:
+
+```
+NEXT_PUBLIC_API_URL=http://localhost:4000
+```
+
+Sem essa variável, o frontend emitirá um erro ao inicializar.

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -1,0 +1,1 @@
+NEXT_PUBLIC_API_URL=http://localhost:4000

--- a/apps/web/app/page.jsx
+++ b/apps/web/app/page.jsx
@@ -1,5 +1,8 @@
 export default function Home() {
-  const apiUrl = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:4000';
+  const apiUrl = process.env.NEXT_PUBLIC_API_URL;
+  if (!apiUrl) {
+    throw new Error('NEXT_PUBLIC_API_URL environment variable is required');
+  }
   return (
     <main style={{
       minHeight: '100vh',

--- a/apps/web/lib/api.js
+++ b/apps/web/lib/api.js
@@ -1,6 +1,10 @@
 import { auth } from './auth';
 
-const BASE = process.env.NEXT_PUBLIC_API_URL || 'http://192.168.0.18:4000';
+const BASE = process.env.NEXT_PUBLIC_API_URL;
+
+if (!BASE) {
+  throw new Error('NEXT_PUBLIC_API_URL environment variable is required');
+}
 
 export async function apiFetch(path, options = {}) {
   const token = auth.get();


### PR DESCRIPTION
## Summary
- require NEXT_PUBLIC_API_URL to be set for frontend and remove hardcoded fallbacks
- document API URL setup and provide sample env file

## Testing
- `NEXT_PUBLIC_API_URL=http://localhost:4000 npm run build`
- `npm test` *(fails: Missing script "test")*
- `npm test` in apps/web *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c1a4457948832fab7b5d4cd310f2bf