### PR TITLE
feat(api): make CORS origin configurable

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -1,0 +1,3 @@
+# Allowed origin for CORS requests
+CORS_ORIGIN=http://localhost:3000
+

--- a/apps/api/index.js
+++ b/apps/api/index.js
@@ -7,12 +7,14 @@ import pkg from "pg";
 dotenv.config();
 const { Pool } = pkg;
 
+const CORS_ORIGIN = process.env.CORS_ORIGIN || "http://localhost:3000";
+
 const app = express();
 app.use(express.json());
 
 // CORS restrito à origem do seu frontend
 app.use((req, res, next) => {
-  const origin = 'http://192.168.0.18:3000';
+  const origin = CORS_ORIGIN;
   res.setHeader('Access-Control-Allow-Origin', origin);
   res.setHeader('Vary', 'Origin');
   res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization');


### PR DESCRIPTION
## Summary
- allow configuring API CORS origin through `CORS_ORIGIN` env var
- document `CORS_ORIGIN` in API `.env.example`

## Testing
- `cd apps/api && npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68c1a442eb30832fbc23e1947ae0f23b