### PR TITLE
Refactor login styles into CSS module with theme tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,24 @@
 # finance-app
 Aplicação para gestão de finanças.
+
+## Design
+
+Tokens de cor e espaçamento estão centralizados em `styles/theme.css`:
+
+- `--color-primary`: #1d4ed8
+- `--color-border`: #cbd5e1
+- `--color-surface-start`: rgba(255, 255, 255, 0.7)
+- `--color-surface-end`: rgba(255, 255, 255, 0.35)
+- `--space-xs`: 10px
+- `--space-sm`: 12px
+- `--space-lg`: 24px
+
+A página de login utiliza CSS Modules (`apps/web/app/login/page.module.css`) com as classes:
+
+- `main`: layout centralizado da página
+- `form`: cartão de login
+- `title`: cabeçalho
+- `input`: campos de entrada
+- `button`: ação principal
+- `message`: mensagens de status
+- `signup`: link para cadastro

--- a/apps/web/app/layout.jsx
+++ b/apps/web/app/layout.jsx
@@ -1,3 +1,4 @@
+import '../../../styles/theme.css';
 import './globals.css';
 
 export const metadata = {

--- a/apps/web/app/login/page.jsx
+++ b/apps/web/app/login/page.jsx
@@ -3,6 +3,7 @@ import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { auth } from '../../lib/auth';
 import { apiFetch } from '../../lib/api';
+import styles from './page.module.css';
 
 export default function LoginPage() {
   const router = useRouter();
@@ -26,25 +27,31 @@ export default function LoginPage() {
   }
 
   return (
-    <main style={{display:'grid',placeItems:'center',minHeight:'100vh'}}>
-      <form onSubmit={onSubmit} style={{
-        width: 380, padding: 24, borderRadius: 20,
-        background: 'linear-gradient(180deg, rgba(255,255,255,0.7), rgba(255,255,255,0.35))',
-        border: '1px solid rgba(255,255,255,0.5)', boxShadow: '0 10px 30px rgba(0,0,0,0.12)'
-      }}>
-        <h2 style={{marginTop:0}}>Entrar</h2>
+    <main className={styles.main}>
+      <form onSubmit={onSubmit} className={styles.form}>
+        <h2 className={styles.title}>Entrar</h2>
         <label>E-mail</label>
-        <input value={email} onChange={e=>setEmail(e.target.value)} required
-          style={{width:'100%', padding:10, borderRadius:12, border:'1px solid #cbd5e1', marginBottom:12}}/>
+        <input
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          required
+          className={styles.input}
+        />
         <label>Senha</label>
-        <input value={senha} onChange={e=>setSenha(e.target.value)} type="password" required
-          style={{width:'100%', padding:10, borderRadius:12, border:'1px solid #cbd5e1', marginBottom:12}}/>
-        <button type="submit" style={{
-          width:'100%', padding:12, borderRadius:12, border:'none', cursor:'pointer',
-          background:'#1d4ed8', color:'white', fontWeight:600
-        }}>Entrar</button>
-        <p style={{marginTop:12, fontSize:13, minHeight:20}}>{msg}</p>
-        <p style={{marginTop:12, fontSize:13}}>Novo aqui? <a href="/register">Criar conta</a></p>
+        <input
+          value={senha}
+          onChange={(e) => setSenha(e.target.value)}
+          type="password"
+          required
+          className={styles.input}
+        />
+        <button type="submit" className={styles.button}>
+          Entrar
+        </button>
+        <p className={styles.message}>{msg}</p>
+        <p className={styles.signup}>
+          Novo aqui? <a href="/register">Criar conta</a>
+        </p>
       </form>
     </main>
   );

--- a/apps/web/app/login/page.module.css
+++ b/apps/web/app/login/page.module.css
@@ -1,0 +1,48 @@
+.main {
+  display: grid;
+  place-items: center;
+  min-height: 100vh;
+}
+
+.form {
+  width: 380px;
+  padding: var(--space-lg);
+  border-radius: 20px;
+  background: linear-gradient(180deg, var(--color-surface-start), var(--color-surface-end));
+  border: 1px solid rgba(255, 255, 255, 0.5);
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.12);
+}
+
+.title {
+  margin-top: 0;
+}
+
+.input {
+  width: 100%;
+  padding: var(--space-xs);
+  border-radius: 12px;
+  border: 1px solid var(--color-border);
+  margin-bottom: var(--space-sm);
+}
+
+.button {
+  width: 100%;
+  padding: var(--space-sm);
+  border-radius: 12px;
+  border: none;
+  cursor: pointer;
+  background: var(--color-primary);
+  color: white;
+  font-weight: 600;
+}
+
+.message {
+  margin-top: var(--space-sm);
+  font-size: 13px;
+  min-height: 20px;
+}
+
+.signup {
+  margin-top: var(--space-sm);
+  font-size: 13px;
+}

--- a/styles/theme.css
+++ b/styles/theme.css
@@ -1,0 +1,9 @@
+:root {
+  --color-primary: #1d4ed8;
+  --color-border: #cbd5e1;
+  --color-surface-start: rgba(255, 255, 255, 0.7);
+  --color-surface-end: rgba(255, 255, 255, 0.35);
+  --space-xs: 10px;
+  --space-sm: 12px;
+  --space-lg: 24px;
+}


### PR DESCRIPTION
## Summary
- extract login page inline styles into `page.module.css`
- centralize color and spacing variables in `styles/theme.css`
- document new design tokens and classes

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm --prefix apps/web test` *(fails: Missing script "test")*
- `npm --prefix apps/web run build`


------
https://chatgpt.com/codex/tasks/task_e_68c18e16877c832fb693b05c867512ed