### PR TITLE
chore: add coverage reporting to api and web apps

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,30 @@
+name: Test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        app: [api, web]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Install dependencies
+        working-directory: apps/${{ matrix.app }}
+        run: npm install
+      - name: Run tests
+        working-directory: apps/${{ matrix.app }}
+        run: npm test -- --passWithNoTests
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-${{ matrix.app }}
+          path: apps/${{ matrix.app }}/coverage

--- a/README.md
+++ b/README.md
@@ -1,2 +1,13 @@
 # finance-app
 Aplicação para gestão de finanças.
+
+## Cobertura de Testes
+
+Cada pacote possui testes configurados com [Jest](https://jestjs.io/). Para gerar o relatório de cobertura execute os comandos abaixo a partir da raiz do projeto:
+
+```bash
+cd apps/api && npm test
+cd ../web && npm test
+```
+
+Ao final da execução será criada uma pasta `coverage` em cada aplicação. O relatório em formato HTML pode ser aberto em `coverage/lcov-report/index.html`. Percentuais são exibidos no terminal e ajudam a identificar partes do código que não estão cobertas por testes.

--- a/apps/api/jest.config.js
+++ b/apps/api/jest.config.js
@@ -1,0 +1,11 @@
+/**
+ * Jest configuration for the API package.
+ * @type {import('jest').Config}
+ */
+export default {
+  testEnvironment: 'node',
+  collectCoverage: true,
+  collectCoverageFrom: ['**/*.js', '!**/*.test.js', '!**/node_modules/**', '!jest.config.js'],
+  coverageDirectory: 'coverage',
+  coverageReporters: ['text', 'lcov'],
+};

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -4,7 +4,8 @@
   "main": "index.js",
   "type": "module",
   "scripts": {
-    "start": "node index.js"
+    "start": "node index.js",
+    "test": "jest --coverage"
   },
   "dependencies": {
     "bcryptjs": "^2.4.3",
@@ -13,5 +14,8 @@
     "jsonwebtoken": "^9.0.2",
     "knex": "^3.1.0",
     "pg": "^8.11.3"
+  },
+  "devDependencies": {
+    "jest": "^29.7.0"
   }
 }

--- a/apps/web/jest.config.js
+++ b/apps/web/jest.config.js
@@ -1,0 +1,11 @@
+/**
+ * Jest configuration for the Web package.
+ * @type {import('jest').Config}
+ */
+module.exports = {
+  testEnvironment: 'jsdom',
+  collectCoverage: true,
+  collectCoverageFrom: ['{app,components,lib}/**/*.{js,jsx,ts,tsx}', '!**/*.test.{js,jsx,ts,tsx}', '!**/node_modules/**', '!jest.config.js'],
+  coverageDirectory: 'coverage',
+  coverageReporters: ['text', 'lcov'],
+};

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -5,11 +5,16 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
-    "start": "next start -p 3000"
+    "start": "next start -p 3000",
+    "test": "jest --coverage"
   },
   "dependencies": {
     "next": "14.2.5",
     "react": "18.3.1",
     "react-dom": "18.3.1"
+  },
+  "devDependencies": {
+    "jest": "^29.7.0",
+    "jest-environment-jsdom": "^29.7.0"
   }
 }


### PR DESCRIPTION
## Summary
- enable Jest coverage collection for API and Web packages
- expose coverage results in CI pipeline
- document how to generate and read coverage reports

## Testing
- `npm test -- --passWithNoTests` (apps/api)
- `npm test -- --passWithNoTests` (apps/web)


------
https://chatgpt.com/codex/tasks/task_e_68c188e2c8a0832f909a2a6ced0c91cf