### PR TITLE
Add test scripts for API and web apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,12 @@
 # finance-app
 Aplicação para gestão de finanças.
+
+## Testes
+
+Para executar todos os testes do projeto, rode:
+
+```bash
+npm test
+```
+
+Esse comando executa os testes da API e da aplicação web.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,10 @@
   "description": "Aplicação de finanças pessoais para Ramon Miranda.",
   "main": "src/server.js",
   "scripts": {
-    "start": "node src/server.js"
+    "start": "node src/server.js",
+    "test:api": "npm --prefix apps/api test",
+    "test:web": "npm --prefix apps/web test",
+    "test": "npm run test:api && npm run test:web"
   },
   "author": "Ramon Miranda",
   "license": "ISC",


### PR DESCRIPTION
## Summary
- add `test:api` and `test:web` scripts in root `package.json`
- aggregate tests via root `npm test` script
- document how to run all tests in `README.md`

## Testing
- `npm test` *(fails: Missing script "test" in sub-apps)*

------
https://chatgpt.com/codex/tasks/task_e_68c1873593f8832fa1d0fe41e65c0926