### PR TITLE
test: add jest and auth page tests to web app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ node_modules/
 npm-debug.log*
 yarn-error.log*
 pnpm-debug.log*
+package-lock.json
 
 # Builds / cache
 .next/

--- a/apps/web/__tests__/LoginPage.test.jsx
+++ b/apps/web/__tests__/LoginPage.test.jsx
@@ -1,0 +1,15 @@
+import { render, screen } from '@testing-library/react';
+import LoginPage from '../app/login/page';
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ replace: jest.fn() }),
+}));
+
+describe('LoginPage', () => {
+  it('renderiza formulário de login', () => {
+    render(<LoginPage />);
+    expect(screen.getByRole('heading', { name: /entrar/i })).toBeInTheDocument();
+    expect(screen.getByText(/e-mail/i)).toBeInTheDocument();
+    expect(screen.getByText(/senha/i)).toBeInTheDocument();
+  });
+});

--- a/apps/web/__tests__/RegisterPage.test.jsx
+++ b/apps/web/__tests__/RegisterPage.test.jsx
@@ -1,0 +1,16 @@
+import { render, screen } from '@testing-library/react';
+import RegisterPage from '../app/register/page';
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ replace: jest.fn() }),
+}));
+
+describe('RegisterPage', () => {
+  it('renderiza formulário de registro', () => {
+    render(<RegisterPage />);
+    expect(screen.getByRole('heading', { name: /criar conta/i })).toBeInTheDocument();
+    expect(screen.getByText(/nome/i)).toBeInTheDocument();
+    expect(screen.getByText(/e-mail/i)).toBeInTheDocument();
+    expect(screen.getByText(/senha/i)).toBeInTheDocument();
+  });
+});

--- a/apps/web/__tests__/Topbar.test.jsx
+++ b/apps/web/__tests__/Topbar.test.jsx
@@ -1,0 +1,14 @@
+import { render, screen } from '@testing-library/react';
+import Topbar from '../components/Topbar';
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ replace: jest.fn() }),
+}));
+
+describe('Topbar', () => {
+  it('exibe saudação do usuário', () => {
+    render(<Topbar user={{ name: 'Ramon' }} />);
+    expect(screen.getByText('Finance App')).toBeInTheDocument();
+    expect(screen.getByText(/Olá, Ramon/)).toBeInTheDocument();
+  });
+});

--- a/apps/web/jest.config.js
+++ b/apps/web/jest.config.js
@@ -1,0 +1,12 @@
+const nextJest = require('next/jest');
+
+const createJestConfig = nextJest({
+  dir: './',
+});
+
+const customJestConfig = {
+  testEnvironment: 'jest-environment-jsdom',
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
+};
+
+module.exports = createJestConfig(customJestConfig);

--- a/apps/web/jest.setup.js
+++ b/apps/web/jest.setup.js
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -5,11 +5,18 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
-    "start": "next start -p 3000"
+    "start": "next start -p 3000",
+    "test": "jest"
   },
   "dependencies": {
     "next": "14.2.5",
     "react": "18.3.1",
     "react-dom": "18.3.1"
+  },
+  "devDependencies": {
+    "@testing-library/jest-dom": "^6.8.0",
+    "@testing-library/react": "^16.3.0",
+    "jest": "^30.1.3",
+    "jest-environment-jsdom": "^30.1.2"
   }
 }


### PR DESCRIPTION
## Summary
- add Jest configuration using next/jest
- include test examples for Topbar and authentication pages
- ignore package-lock in web app

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c183eb08e0832f855df1aa46d2696c