### PR TITLE
Use ALLOWED_ORIGIN env var for API CORS

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+ALLOWED_ORIGIN=http://localhost:3000

--- a/apps/api/index.js
+++ b/apps/api/index.js
@@ -12,7 +12,7 @@ app.use(express.json());
 
 // CORS restrito à origem do seu frontend
 app.use((req, res, next) => {
-  const origin = 'http://192.168.0.18:3000';
+  const origin = process.env.ALLOWED_ORIGIN || 'http://localhost:3000';
   res.setHeader('Access-Control-Allow-Origin', origin);
   res.setHeader('Vary', 'Origin');
   res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization');

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,8 @@ services:
   api:
     build: ./apps/api
     env_file: ./apps/api/.env
+    environment:
+      - ALLOWED_ORIGIN=${ALLOWED_ORIGIN:-http://localhost:3000}
     ports:
       - "4000:4000"
     depends_on:


### PR DESCRIPTION
## Summary
- switch API CORS origin to use `ALLOWED_ORIGIN` env var with safe fallback
- document and wire up `ALLOWED_ORIGIN` through `.env` and `docker-compose`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c1fab368b0832fa65a3a059fd00845