### PR TITLE
refactor: remove API URL fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
 # finance-app
 Aplicação para gestão de finanças.
+
+## Configuração
+
+A aplicação web espera a variável de ambiente `NEXT_PUBLIC_API_URL` contendo a URL base da API.

--- a/apps/web/lib/api.js
+++ b/apps/web/lib/api.js
@@ -1,6 +1,6 @@
 import { auth } from './auth';
 
-const BASE = process.env.NEXT_PUBLIC_API_URL || 'http://192.168.0.18:4000';
+const BASE = process.env.NEXT_PUBLIC_API_URL;
 
 export async function apiFetch(path, options = {}) {
   const token = auth.get();


### PR DESCRIPTION
## Summary
- remove hardcoded API URL fallback in web API helper
- document NEXT_PUBLIC_API_URL requirement in README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c1fb758b94832f87b908e2f42b8506