### PR TITLE
Remove Topbar duplication in dashboard

### DIFF
--- a/apps/web/app/(app)/dashboard/page.jsx
+++ b/apps/web/app/(app)/dashboard/page.jsx
@@ -3,7 +3,6 @@ import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { auth } from '@/lib/auth';
 import { getMe } from '@/lib/api';
-import Topbar from '@/components/Topbar';
 
 export default function Dashboard() {
   const router = useRouter();
@@ -22,19 +21,16 @@ export default function Dashboard() {
   if (!user) return null;
 
   return (
-    <>
-      <Topbar user={user} />
-      <main style={{minHeight:'100vh', padding:24}}>
-        <div style={{
-          padding: 20, borderRadius: 20,
-          background: 'linear-gradient(180deg, rgba(255,255,255,0.7), rgba(255,255,255,0.35))',
-          border: '1px solid rgba(255,255,255,0.5)', boxShadow: '0 10px 30px rgba(0,0,0,0.12)'
-        }}>
-          <h2 style={{marginTop:0}}>Painel</h2>
-          <p>Bem-vindo, <strong>{user.name}</strong> ({user.email}).</p>
-          <p>Em breve: saldos, cartões, investimentos, objetivos e Pluggy.</p>
-        </div>
-      </main>
-    </>
+    <main style={{minHeight:'100vh', padding:24}}>
+      <div style={{
+        padding: 20, borderRadius: 20,
+        background: 'linear-gradient(180deg, rgba(255,255,255,0.7), rgba(255,255,255,0.35))',
+        border: '1px solid rgba(255,255,255,0.5)', boxShadow: '0 10px 30px rgba(0,0,0,0.12)'
+      }}>
+        <h2 style={{marginTop:0}}>Painel</h2>
+        <p>Bem-vindo, <strong>{user.name}</strong> ({user.email}).</p>
+        <p>Em breve: saldos, cartões, investimentos, objetivos e Pluggy.</p>
+      </div>
+    </main>
   );
 }


### PR DESCRIPTION
## Summary
- Remove Topbar import and component from dashboard page
- Confirm other pages under (app) rely on layout for Topbar

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c1fc62b018832fba17f25ef88baa91