### PR TITLE
feat: add encrypted accounts and cards

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,16 @@ Aplicação para gestão de finanças.
 ## Configuração
 
 A aplicação web espera a variável de ambiente `NEXT_PUBLIC_API_URL` contendo a URL base da API.
+
+## API
+
+A API expõe endpoints REST para gerenciar usuários, contas bancárias e cartões.
+
+- `GET /accounts`, `POST /accounts`, `GET /accounts/:id`, `PUT /accounts/:id`, `DELETE /accounts/:id`
+- `GET /cards`, `POST /cards`, `GET /cards/:id`, `PUT /cards/:id`, `DELETE /cards/:id`
+
+Campos sensíveis dessas entidades são armazenados criptografados com AES‑256 através da extensão `pgcrypto` do PostgreSQL.
+
+### Variáveis de ambiente
+
+- `DATA_ENCRYPTION_KEY`: chave usada para criptografia simétrica dos dados (opcional, padrão `devkey`).

--- a/apps/api/index.js
+++ b/apps/api/index.js
@@ -30,6 +30,8 @@ const pool = new Pool({
   password: process.env.DB_PASSWORD || "postgres",
 });
 
+const ENC_KEY = process.env.DATA_ENCRYPTION_KEY || "devkey";
+
 // Cria extensão e tabela users se não existirem
 async function ensureSchema() {
   try { await pool.query('CREATE EXTENSION IF NOT EXISTS "pgcrypto";'); } catch (_) {}
@@ -39,6 +41,30 @@ async function ensureSchema() {
       name TEXT NOT NULL,
       email TEXT UNIQUE NOT NULL,
       password_hash TEXT NOT NULL,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    );
+  `);
+
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS accounts (
+      id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+      user_id UUID REFERENCES users(id) ON DELETE CASCADE,
+      agency TEXT NOT NULL,
+      account_number BYTEA NOT NULL,
+      manager BYTEA,
+      phone BYTEA,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    );
+  `);
+
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS cards (
+      id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+      user_id UUID REFERENCES users(id) ON DELETE CASCADE,
+      card_number BYTEA NOT NULL,
+      expiration TEXT NOT NULL,
+      cvc BYTEA NOT NULL,
+      card_limit NUMERIC NOT NULL,
       created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
     );
   `);
@@ -112,6 +138,199 @@ app.post("/auth/login", async (req, res) => {
 app.get("/me", authMiddleware, async (req, res) => {
   const { rows } = await pool.query("SELECT id, name, email, created_at FROM users WHERE id = $1", [req.user.sub]);
   res.json({ user: rows[0] || null });
+});
+
+// Accounts CRUD
+app.get("/accounts", authMiddleware, async (req, res) => {
+  const { rows } = await pool.query(
+    `SELECT id, agency,
+            pgp_sym_decrypt(account_number, $2) AS number,
+            pgp_sym_decrypt(manager, $2) AS manager,
+            pgp_sym_decrypt(phone, $2) AS phone
+       FROM accounts
+       WHERE user_id = $1
+       ORDER BY created_at DESC`,
+    [req.user.sub, ENC_KEY]
+  );
+  res.json({ accounts: rows });
+});
+
+app.post("/accounts", authMiddleware, async (req, res) => {
+  try {
+    const { agency, number, manager, phone } = req.body || {};
+    if (!agency || !number) return res.status(400).json({ error: "VALIDATION_ERROR" });
+    const { rows } = await pool.query(
+      `INSERT INTO accounts (user_id, agency, account_number, manager, phone)
+         VALUES ($1, $2,
+                 pgp_sym_encrypt($3, $6, 'cipher-algo=aes256'),
+                 pgp_sym_encrypt($4, $6, 'cipher-algo=aes256'),
+                 pgp_sym_encrypt($5, $6, 'cipher-algo=aes256'))
+       RETURNING id, agency,
+                 pgp_sym_decrypt(account_number, $6) AS number,
+                 pgp_sym_decrypt(manager, $6) AS manager,
+                 pgp_sym_decrypt(phone, $6) AS phone`,
+      [req.user.sub, agency, number, manager, phone, ENC_KEY]
+    );
+    res.status(201).json({ account: rows[0] });
+  } catch (e) {
+    console.error(e);
+    res.status(500).json({ error: "INTERNAL_ERROR" });
+  }
+});
+
+app.get("/accounts/:id", authMiddleware, async (req, res) => {
+  const { rows } = await pool.query(
+    `SELECT id, agency,
+            pgp_sym_decrypt(account_number, $3) AS number,
+            pgp_sym_decrypt(manager, $3) AS manager,
+            pgp_sym_decrypt(phone, $3) AS phone
+       FROM accounts
+       WHERE id = $1 AND user_id = $2`,
+    [req.params.id, req.user.sub, ENC_KEY]
+  );
+  const account = rows[0];
+  if (!account) return res.status(404).json({ error: "NOT_FOUND" });
+  res.json({ account });
+});
+
+app.put("/accounts/:id", authMiddleware, async (req, res) => {
+  try {
+    const { agency, number, manager, phone } = req.body || {};
+    if (!agency || !number) return res.status(400).json({ error: "VALIDATION_ERROR" });
+    const result = await pool.query(
+      `UPDATE accounts SET
+         agency = $3,
+         account_number = pgp_sym_encrypt($4, $7, 'cipher-algo=aes256'),
+         manager = pgp_sym_encrypt($5, $7, 'cipher-algo=aes256'),
+         phone = pgp_sym_encrypt($6, $7, 'cipher-algo=aes256')
+       WHERE id = $1 AND user_id = $2`,
+      [req.params.id, req.user.sub, agency, number, manager, phone, ENC_KEY]
+    );
+    if (result.rowCount === 0) return res.status(404).json({ error: "NOT_FOUND" });
+    const { rows } = await pool.query(
+      `SELECT id, agency,
+              pgp_sym_decrypt(account_number, $3) AS number,
+              pgp_sym_decrypt(manager, $3) AS manager,
+              pgp_sym_decrypt(phone, $3) AS phone
+         FROM accounts
+         WHERE id = $1 AND user_id = $2`,
+      [req.params.id, req.user.sub, ENC_KEY]
+    );
+    res.json({ account: rows[0] });
+  } catch (e) {
+    console.error(e);
+    res.status(500).json({ error: "INTERNAL_ERROR" });
+  }
+});
+
+app.delete("/accounts/:id", authMiddleware, async (req, res) => {
+  const result = await pool.query(
+    "DELETE FROM accounts WHERE id = $1 AND user_id = $2",
+    [req.params.id, req.user.sub]
+  );
+  if (result.rowCount === 0) return res.status(404).json({ error: "NOT_FOUND" });
+  res.status(204).send();
+});
+
+// Cards CRUD
+app.get("/cards", authMiddleware, async (req, res) => {
+  const { rows } = await pool.query(
+    `SELECT id,
+            pgp_sym_decrypt(card_number, $2) AS number,
+            expiration,
+            pgp_sym_decrypt(cvc, $2) AS cvc,
+            card_limit AS limit
+       FROM cards
+       WHERE user_id = $1
+       ORDER BY created_at DESC`,
+    [req.user.sub, ENC_KEY]
+  );
+  res.json({ cards: rows });
+});
+
+app.post("/cards", authMiddleware, async (req, res) => {
+  try {
+    const { number, expiration, cvc, limit } = req.body || {};
+    if (!number || !expiration || !cvc || limit == null) {
+      return res.status(400).json({ error: "VALIDATION_ERROR" });
+    }
+    const { rows } = await pool.query(
+      `INSERT INTO cards (user_id, card_number, expiration, cvc, card_limit)
+         VALUES ($1,
+                 pgp_sym_encrypt($2, $6, 'cipher-algo=aes256'),
+                 $3,
+                 pgp_sym_encrypt($4, $6, 'cipher-algo=aes256'),
+                 $5)
+       RETURNING id,
+                 pgp_sym_decrypt(card_number, $6) AS number,
+                 expiration,
+                 pgp_sym_decrypt(cvc, $6) AS cvc,
+                 card_limit AS limit`,
+      [req.user.sub, number, expiration, cvc, limit, ENC_KEY]
+    );
+    res.status(201).json({ card: rows[0] });
+  } catch (e) {
+    console.error(e);
+    res.status(500).json({ error: "INTERNAL_ERROR" });
+  }
+});
+
+app.get("/cards/:id", authMiddleware, async (req, res) => {
+  const { rows } = await pool.query(
+    `SELECT id,
+            pgp_sym_decrypt(card_number, $3) AS number,
+            expiration,
+            pgp_sym_decrypt(cvc, $3) AS cvc,
+            card_limit AS limit
+       FROM cards
+       WHERE id = $1 AND user_id = $2`,
+    [req.params.id, req.user.sub, ENC_KEY]
+  );
+  const card = rows[0];
+  if (!card) return res.status(404).json({ error: "NOT_FOUND" });
+  res.json({ card });
+});
+
+app.put("/cards/:id", authMiddleware, async (req, res) => {
+  try {
+    const { number, expiration, cvc, limit } = req.body || {};
+    if (!number || !expiration || !cvc || limit == null) {
+      return res.status(400).json({ error: "VALIDATION_ERROR" });
+    }
+    const result = await pool.query(
+      `UPDATE cards SET
+         card_number = pgp_sym_encrypt($3, $7, 'cipher-algo=aes256'),
+         expiration = $4,
+         cvc = pgp_sym_encrypt($5, $7, 'cipher-algo=aes256'),
+         card_limit = $6
+       WHERE id = $1 AND user_id = $2`,
+      [req.params.id, req.user.sub, number, expiration, cvc, limit, ENC_KEY]
+    );
+    if (result.rowCount === 0) return res.status(404).json({ error: "NOT_FOUND" });
+    const { rows } = await pool.query(
+      `SELECT id,
+              pgp_sym_decrypt(card_number, $3) AS number,
+              expiration,
+              pgp_sym_decrypt(cvc, $3) AS cvc,
+              card_limit AS limit
+         FROM cards
+         WHERE id = $1 AND user_id = $2`,
+      [req.params.id, req.user.sub, ENC_KEY]
+    );
+    res.json({ card: rows[0] });
+  } catch (e) {
+    console.error(e);
+    res.status(500).json({ error: "INTERNAL_ERROR" });
+  }
+});
+
+app.delete("/cards/:id", authMiddleware, async (req, res) => {
+  const result = await pool.query(
+    "DELETE FROM cards WHERE id = $1 AND user_id = $2",
+    [req.params.id, req.user.sub]
+  );
+  if (result.rowCount === 0) return res.status(404).json({ error: "NOT_FOUND" });
+  res.status(204).send();
 });
 
 const PORT = process.env.PORT || 4000;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,7 @@ services:
     env_file: ./apps/api/.env
     environment:
       - ALLOWED_ORIGIN=${ALLOWED_ORIGIN:-http://localhost:3000}
+      - DATA_ENCRYPTION_KEY=${DATA_ENCRYPTION_KEY:-devkey}
     ports:
       - "4000:4000"
     depends_on:


### PR DESCRIPTION
## Summary
- add accounts and cards tables with AES-256 encrypted fields
- expose CRUD endpoints for accounts and cards
- document API endpoints and encryption key usage

## Testing
- `node --check apps/api/index.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c1fdd6d530832f967cef17144cc5a1