### PR TITLE
feat(api): allow custom Pluggy base URL

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,2 @@
 ALLOWED_ORIGIN=http://localhost:3000
+PLUGGY_BASE_URL=https://api.meupluggy.com

--- a/README.md
+++ b/README.md
@@ -22,3 +22,5 @@ Campos sensíveis dessas entidades são armazenados criptografados com AES‑256
 ### Variáveis de ambiente
 
 - `DATA_ENCRYPTION_KEY`: chave usada para criptografia simétrica dos dados (opcional, padrão `devkey`).
+- `PLUGGY_BASE_URL`: URL base da API do Pluggy (padrão `https://api.pluggy.ai`).
+  Use `https://api.meupluggy.com` para conectar ao MeuPluggy.

--- a/apps/api/index.js
+++ b/apps/api/index.js
@@ -3,9 +3,16 @@ import dotenv from "dotenv";
 import bcrypt from "bcryptjs";
 import jwt from "jsonwebtoken";
 import pkg from "pg";
+import Pluggy from "pluggy-sdk";
 
 dotenv.config();
 const { Pool } = pkg;
+
+const pluggy = new Pluggy({
+  clientId: process.env.PLUGGY_CLIENT_ID,
+  clientSecret: process.env.PLUGGY_CLIENT_SECRET,
+  baseUrl: process.env.PLUGGY_BASE_URL || "https://api.pluggy.ai",
+});
 
 const app = express();
 app.use(express.json());


### PR DESCRIPTION
## Summary
- allow configuring Pluggy client's base URL with PLUGGY_BASE_URL
- document Pluggy base URL env var and sample value for MeuPluggy

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c2016de39c832f8c8431d474b7f719