### PR TITLE
feat: add account and card management

### DIFF
--- a/apps/web/app/(app)/contas-e-cartoes/page.jsx
+++ b/apps/web/app/(app)/contas-e-cartoes/page.jsx
@@ -2,37 +2,90 @@
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { auth } from '@/lib/auth';
-import { getCards } from '@/lib/api';
+import { getAccounts, getCards } from '@/lib/api';
+import AccountModal from '@/components/AccountModal';
+import CardModal from '@/components/CardModal';
 
 export default function Page() {
   const router = useRouter();
+  const [tab, setTab] = useState('accounts');
+  const [accounts, setAccounts] = useState([]);
   const [cards, setCards] = useState([]);
+  const [showAccountModal, setShowAccountModal] = useState(false);
+  const [showCardModal, setShowCardModal] = useState(false);
+
+  const loadAccounts = () =>
+    getAccounts().then((d) => setAccounts(d.accounts));
+
+  const loadCards = () =>
+    getCards().then((d) => setCards(d.cards));
 
   useEffect(() => {
     if (!auth.isAuthenticated()) {
       router.replace('/login');
       return;
     }
-    getCards()
-      .then((d) => setCards(d.cards))
-      .catch(() => router.replace('/login'));
+    Promise.all([loadAccounts(), loadCards()]).catch(() => router.replace('/login'));
   }, [router]);
 
   return (
     <section style={{
-      padding: 20, borderRadius: 20,
+      padding: 20,
+      borderRadius: 20,
       background: 'linear-gradient(180deg, rgba(255,255,255,0.7), rgba(255,255,255,0.35))',
-      border: '1px solid rgba(0,0,0,0.06)', boxShadow: '0 10px 30px rgba(0,0,0,0.12)'
+      border: '1px solid rgba(0,0,0,0.06)',
+      boxShadow: '0 10px 30px rgba(0,0,0,0.12)'
     }}>
-      <h2 style={{marginTop:0}}>Contas e Cartões</h2>
-      {cards.length === 0 ? (
-        <p>Nenhum cartão cadastrado.</p>
-      ) : (
-        <ul>
-          {cards.map((c) => (
-            <li key={c.id}>**** **** **** {c.number}</li>
-          ))}
-        </ul>
+      <h2 style={{ marginTop: 0 }}>Contas e Cartões</h2>
+      <div style={{ marginBottom: 20, display: 'flex', gap: 10 }}>
+        <button onClick={() => setTab('accounts')} disabled={tab === 'accounts'}>
+          Contas
+        </button>
+        <button onClick={() => setTab('cards')} disabled={tab === 'cards'}>
+          Cartões
+        </button>
+      </div>
+
+      {tab === 'accounts' && (
+        <div>
+          <button onClick={() => setShowAccountModal(true)}>Nova Conta</button>
+          {accounts.length === 0 ? (
+            <p>Nenhuma conta cadastrada.</p>
+          ) : (
+            <ul>
+              {accounts.map((a) => (
+                <li key={a.id}>
+                  {a.agency} - ****{a.number.slice(-4)}
+                </li>
+              ))}
+            </ul>
+          )}
+          <AccountModal
+            open={showAccountModal}
+            onClose={() => setShowAccountModal(false)}
+            onCreated={loadAccounts}
+          />
+        </div>
+      )}
+
+      {tab === 'cards' && (
+        <div>
+          <button onClick={() => setShowCardModal(true)}>Novo Cartão</button>
+          {cards.length === 0 ? (
+            <p>Nenhum cartão cadastrado.</p>
+          ) : (
+            <ul>
+              {cards.map((c) => (
+                <li key={c.id}>**** **** **** {c.number}</li>
+              ))}
+            </ul>
+          )}
+          <CardModal
+            open={showCardModal}
+            onClose={() => setShowCardModal(false)}
+            onCreated={loadCards}
+          />
+        </div>
       )}
     </section>
   );

--- a/apps/web/components/AccountModal.jsx
+++ b/apps/web/components/AccountModal.jsx
@@ -1,0 +1,42 @@
+import { useState } from 'react';
+import Modal from './Modal';
+import { createAccount } from '@/lib/api';
+
+export default function AccountModal({ open, onClose, onCreated }) {
+  const [form, setForm] = useState({ agency: '', number: '', digit: '', manager: '', phone: '' });
+
+  const handleChange = (e) => {
+    setForm({ ...form, [e.target.name]: e.target.value });
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    try {
+      await createAccount({
+        agency: form.agency,
+        number: `${form.number}${form.digit}`,
+        manager: form.manager,
+        phone: form.phone,
+      });
+      setForm({ agency: '', number: '', digit: '', manager: '', phone: '' });
+      onCreated?.();
+      onClose();
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  return (
+    <Modal open={open} onClose={onClose}>
+      <h3>Nova Conta</h3>
+      <form onSubmit={handleSubmit} style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+        <input name="agency" placeholder="Agência" value={form.agency} onChange={handleChange} required />
+        <input name="number" placeholder="Número" value={form.number} onChange={handleChange} required />
+        <input name="digit" placeholder="Dígito" value={form.digit} onChange={handleChange} required />
+        <input name="manager" placeholder="Gerente" value={form.manager} onChange={handleChange} />
+        <input name="phone" placeholder="Telefone" value={form.phone} onChange={handleChange} />
+        <button type="submit">Salvar</button>
+      </form>
+    </Modal>
+  );
+}

--- a/apps/web/components/CardModal.jsx
+++ b/apps/web/components/CardModal.jsx
@@ -1,0 +1,41 @@
+import { useState } from 'react';
+import Modal from './Modal';
+import { createCard } from '@/lib/api';
+
+export default function CardModal({ open, onClose, onCreated }) {
+  const [form, setForm] = useState({ number: '', expiration: '', cvc: '', limit: '' });
+
+  const handleChange = (e) => {
+    setForm({ ...form, [e.target.name]: e.target.value });
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    try {
+      await createCard({
+        number: form.number,
+        expiration: form.expiration,
+        cvc: form.cvc,
+        limit: Number(form.limit),
+      });
+      setForm({ number: '', expiration: '', cvc: '', limit: '' });
+      onCreated?.();
+      onClose();
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  return (
+    <Modal open={open} onClose={onClose}>
+      <h3>Novo Cartão</h3>
+      <form onSubmit={handleSubmit} style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+        <input name="number" placeholder="Número" value={form.number} onChange={handleChange} required />
+        <input name="expiration" placeholder="Vencimento" value={form.expiration} onChange={handleChange} required />
+        <input name="cvc" placeholder="CVC" value={form.cvc} onChange={handleChange} required />
+        <input name="limit" placeholder="Limite" type="number" value={form.limit} onChange={handleChange} required />
+        <button type="submit">Salvar</button>
+      </form>
+    </Modal>
+  );
+}

--- a/apps/web/components/Modal.jsx
+++ b/apps/web/components/Modal.jsx
@@ -1,0 +1,43 @@
+import React from 'react';
+
+export default function Modal({ open, onClose, children }) {
+  if (!open) return null;
+  return (
+    <div style={{
+      position: 'fixed',
+      top: 0,
+      left: 0,
+      right: 0,
+      bottom: 0,
+      background: 'rgba(0,0,0,0.5)',
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      zIndex: 1000,
+    }}>
+      <div style={{
+        background: '#fff',
+        padding: 20,
+        borderRadius: 8,
+        minWidth: 300,
+        position: 'relative'
+      }}>
+        <button
+          onClick={onClose}
+          style={{
+            position: 'absolute',
+            top: 10,
+            right: 10,
+            border: 'none',
+            background: 'transparent',
+            fontSize: 16,
+            cursor: 'pointer'
+          }}
+        >
+          &times;
+        </button>
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/lib/api.js
+++ b/apps/web/lib/api.js
@@ -28,3 +28,21 @@ export async function getMe() {
 export async function getCards() {
   return apiFetch('/cards');
 }
+
+export async function getAccounts() {
+  return apiFetch('/accounts');
+}
+
+export async function createAccount(data) {
+  return apiFetch('/accounts', {
+    method: 'POST',
+    body: JSON.stringify(data),
+  });
+}
+
+export async function createCard(data) {
+  return apiFetch('/cards', {
+    method: 'POST',
+    body: JSON.stringify(data),
+  });
+}


### PR DESCRIPTION
## Summary
- add tabbed accounts and cards page with modal forms
- extend API helpers for accounts and cards

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c20caf300c832fae74c7efdb8508c1